### PR TITLE
Improve s0c auth flow and psql bootstrap experience

### DIFF
--- a/apps/s0c/.env.sample
+++ b/apps/s0c/.env.sample
@@ -1,2 +1,3 @@
 S0C_AUTH_BASE_URL="http://localhost:8020"
 S0C_API_BASE_URL="http://localhost:8080"
+S0C_REFRESH_TOKEN_COOKIE_NAME="__Secure-refresh_token"

--- a/apps/s0c/README.md
+++ b/apps/s0c/README.md
@@ -11,8 +11,8 @@
 # Собрать локально:
 go build -o s0c .
 
-# Аутентифицироваться:
-./s0c auth
+# Войти используя username/email и пароль:
+./s0c auth login
 
 # Открыть psql:
 s0c psql

--- a/apps/s0c/README_EN.md
+++ b/apps/s0c/README_EN.md
@@ -11,8 +11,8 @@ English | [Русский](README.md)
 # Build locally:
 go build -o s0c .
 
-# Authenticate:
-./s0c auth
+# Login using username/email and password:
+./s0c auth login
 
 # Jump into psql:
 s0c psql

--- a/apps/s0c/internal/app/auth.go
+++ b/apps/s0c/internal/app/auth.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/sb0rka/sb0rka/apps/s0c/internal/auth"
 	"github.com/sb0rka/sb0rka/apps/s0c/internal/client"
+	"github.com/sb0rka/sb0rka/apps/s0c/internal/config"
 )
 
 type AuthService struct {
@@ -23,25 +25,80 @@ func NewAuthService(version string) *AuthService {
 	}
 }
 
-func (s *AuthService) SaveAndVerifyToken(ctx context.Context, refreshToken string) error {
-	token := strings.TrimSpace(refreshToken)
-	if token == "" {
-		return fmt.Errorf("refresh token cannot be empty")
+func (s *AuthService) Login(ctx context.Context, usernameOrEmail string, password string) error {
+	usernameOrEmail = strings.TrimSpace(usernameOrEmail)
+	if usernameOrEmail == "" {
+		return fmt.Errorf("username or email cannot be empty")
+	}
+	password = strings.TrimSpace(password)
+	if password == "" {
+		return fmt.Errorf("password cannot be empty")
 	}
 
-	if err := auth.SaveState(auth.AuthState{RefreshToken: token}); err != nil {
+	_, authBaseURL := ResolveBaseURLs(s.getenv)
+	refreshCookieName := ResolveRefreshTokenCookieName(s.getenv)
+	authClient := s.newClient(
+		authBaseURL,
+		fmt.Sprintf("s0c/%s", s.version),
+		client.WithRefreshTokenCookieName(refreshCookieName),
+	)
+
+	accessToken, refreshToken, expiresAt, err := authClient.Login(ctx, usernameOrEmail, password)
+	if err != nil {
+		return fmt.Errorf("login failed: %w", err)
+	}
+
+	state := auth.AuthState{
+		RefreshToken: refreshToken,
+		AccessToken:  accessToken,
+	}
+	state.AccessTokenExpiresAt = normalizeAccessTokenExpiry(expiresAt)
+
+	if err := auth.SaveState(state); err != nil {
 		return fmt.Errorf("save auth state: %w", err)
 	}
 
-	_, authBaseURL, err := ResolveBaseURLs(s.getenv)
+	return nil
+}
+
+func (s *AuthService) Logout(ctx context.Context) error {
+	_, authBaseURL := ResolveBaseURLs(s.getenv)
+	refreshCookieName := ResolveRefreshTokenCookieName(s.getenv)
+	authClient := s.newClient(
+		authBaseURL,
+		fmt.Sprintf("s0c/%s", s.version),
+		client.WithRefreshTokenCookieName(refreshCookieName),
+	)
+
+	bearer, err := auth.GetValidAccessToken(ctx, authClient)
 	if err != nil {
-		return fmt.Errorf("resolve auth base URL: %w", err)
+		return err
+	}
+	if err := authClient.Logout(ctx, bearer); err != nil {
+		return fmt.Errorf("logout request failed: %w", err)
 	}
 
-	authClient := s.newClient(authBaseURL, fmt.Sprintf("s0c/%s", s.version))
-	if _, err := auth.ForceRefreshAccessToken(ctx, authClient); err != nil {
-		return fmt.Errorf("auth failed to fetch access token: %w", err)
+	if err := auth.SaveState(auth.AuthState{}); err != nil {
+		return fmt.Errorf("clear auth state: %w", err)
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		return err
+	}
+	cfg.ProjectID = ""
+	cfg.DatabaseID = ""
+	if err := config.Save(cfg); err != nil {
+		return fmt.Errorf("clear config defaults: %w", err)
 	}
 
 	return nil
+}
+
+func normalizeAccessTokenExpiry(expiresAt *time.Time) *time.Time {
+	if expiresAt == nil || expiresAt.IsZero() {
+		return nil
+	}
+	t := expiresAt.UTC()
+	return &t
 }

--- a/apps/s0c/internal/app/env.go
+++ b/apps/s0c/internal/app/env.go
@@ -1,39 +1,45 @@
 package app
 
 import (
-	"errors"
 	"os"
 	"strings"
 )
 
 const (
-	EnvAPIBaseURL  = "S0C_API_BASE_URL"
-	EnvAuthBaseURL = "S0C_AUTH_BASE_URL"
+	DefaultAPIBaseURL             = "https://api.sb0rka.ru"
+	DefaultAuthBaseURL            = "https://auth.sb0rka.ru"
+	DefaultRefreshTokenCookieName = "__Secure-refresh_token"
 )
 
-func ResolveBaseURLs(getenv func(string) string) (string, string, error) {
-	apiBaseURL, err := resolveRequiredBaseURL(getenv, EnvAPIBaseURL)
-	if err != nil {
-		return "", "", err
+func ResolveBaseURLs(getenv func(string) string) (string, string) {
+	if getenv == nil {
+		getenv = os.Getenv
 	}
-
-	authBaseURL, err := resolveRequiredBaseURL(getenv, EnvAuthBaseURL)
-	if err != nil {
-		return "", "", err
-	}
-
-	return apiBaseURL, authBaseURL, nil
+	return resolveBaseURL(getenv, "S0C_API_BASE_URL", DefaultAPIBaseURL),
+		resolveBaseURL(getenv, "S0C_AUTH_BASE_URL", DefaultAuthBaseURL)
 }
 
-func resolveRequiredBaseURL(getenv func(string) string, key string) (string, error) {
+func ResolveRefreshTokenCookieName(getenv func(string) string) string {
 	if getenv == nil {
 		getenv = os.Getenv
 	}
 
-	baseURL := strings.TrimSpace(getenv(key))
-	if baseURL == "" {
-		return "", errors.New(key + " is not set")
+	// Prefer explicit CLI override, then shared backend variable.
+	name := strings.TrimSpace(getenv("S0C_REFRESH_TOKEN_COOKIE_NAME"))
+	if name == "" {
+		name = strings.TrimSpace(getenv("REFRESH_TOKEN_COOKIE_NAME"))
+	}
+	if name == "" {
+		name = DefaultRefreshTokenCookieName
 	}
 
-	return strings.TrimRight(baseURL, "/"), nil
+	return name
+}
+
+func resolveBaseURL(getenv func(string) string, key, defaultURL string) string {
+	s := strings.TrimSpace(getenv(key))
+	if s == "" {
+		s = defaultURL
+	}
+	return strings.TrimRight(s, "/")
 }

--- a/apps/s0c/internal/app/platform.go
+++ b/apps/s0c/internal/app/platform.go
@@ -1,27 +1,33 @@
 package app
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
+	"strings"
 
 	"github.com/sb0rka/sb0rka/apps/s0c/internal/auth"
 	"github.com/sb0rka/sb0rka/apps/s0c/internal/client"
 	"github.com/sb0rka/sb0rka/packages/contract"
+	"golang.org/x/term"
 )
 
 type PlatformService struct {
-	getenv    func(string) string
-	version   string
-	newClient func(baseURL string, userAgent string, opts ...client.ClientOption) *client.Client
+	getenv            func(string) string
+	version           string
+	newClient         func(baseURL string, userAgent string, opts ...client.ClientOption) *client.Client
+	promptCredentials func() (string, string, error)
 }
 
 func NewPlatformService(version string) *PlatformService {
 	return &PlatformService{
-		getenv:    nil,
-		version:   version,
-		newClient: client.NewClient,
+		getenv:            nil,
+		version:           version,
+		newClient:         client.NewClient,
+		promptCredentials: promptLoginCredentials,
 	}
 }
 
@@ -45,11 +51,41 @@ func (s *PlatformService) ListProjects(ctx context.Context) (contract.ProjectLis
 	})
 }
 
+func (s *PlatformService) CreateProject(ctx context.Context, name string, description string) (contract.ProjectResponse, error) {
+	return runAuthorized(s, ctx, func(ctx context.Context, apiClient *client.Client, bearer string) (contract.ProjectResponse, error) {
+		payload, err := client.CreateProject(ctx, apiClient, bearer, name, description)
+		if err != nil {
+			return contract.ProjectResponse{}, fmt.Errorf("create project: %w", err)
+		}
+		return payload, nil
+	})
+}
+
+func (s *PlatformService) GetProject(ctx context.Context, projectID string) (contract.ProjectResponse, error) {
+	return runAuthorized(s, ctx, func(ctx context.Context, apiClient *client.Client, bearer string) (contract.ProjectResponse, error) {
+		payload, err := client.GetProject(ctx, apiClient, bearer, projectID)
+		if err != nil {
+			return contract.ProjectResponse{}, fmt.Errorf("get project: %w", err)
+		}
+		return payload, nil
+	})
+}
+
 func (s *PlatformService) ListDatabases(ctx context.Context, projectID string) (contract.DatabaseListResponse, error) {
 	return runAuthorized(s, ctx, func(ctx context.Context, apiClient *client.Client, bearer string) (contract.DatabaseListResponse, error) {
 		payload, err := client.ListDatabases(ctx, apiClient, bearer, projectID)
 		if err != nil {
 			return contract.DatabaseListResponse{}, fmt.Errorf("list databases: %w", err)
+		}
+		return payload, nil
+	})
+}
+
+func (s *PlatformService) GetDatabase(ctx context.Context, projectID string, databaseID string) (contract.DatabaseResponse, error) {
+	return runAuthorized(s, ctx, func(ctx context.Context, apiClient *client.Client, bearer string) (contract.DatabaseResponse, error) {
+		payload, err := client.GetDatabase(ctx, apiClient, bearer, projectID, databaseID)
+		if err != nil {
+			return contract.DatabaseResponse{}, fmt.Errorf("get database: %w", err)
 		}
 		return payload, nil
 	})
@@ -82,16 +118,14 @@ func runAuthorized[T any](
 ) (T, error) {
 	var zero T
 
-	apiBaseURL, authBaseURL, err := ResolveBaseURLs(s.getenv)
-	if err != nil {
-		return zero, err
-	}
+	apiBaseURL, authBaseURL := ResolveBaseURLs(s.getenv)
+	refreshCookieName := ResolveRefreshTokenCookieName(s.getenv)
 
 	userAgent := fmt.Sprintf("s0c/%s", s.version)
 	apiClient := s.newClient(apiBaseURL, userAgent)
-	authClient := s.newClient(authBaseURL, userAgent)
+	authClient := s.newClient(authBaseURL, userAgent, client.WithRefreshTokenCookieName(refreshCookieName))
 
-	bearer, err := auth.GetValidAccessToken(ctx, authClient)
+	bearer, err := getOrLoginAccessToken(ctx, s, authClient)
 	if err != nil {
 		return zero, err
 	}
@@ -112,4 +146,75 @@ func runAuthorized[T any](
 	}
 
 	return v, nil
+}
+
+func getOrLoginAccessToken(ctx context.Context, s *PlatformService, authClient *client.Client) (string, error) {
+	bearer, err := auth.GetValidAccessToken(ctx, authClient)
+	if err == nil {
+		return bearer, nil
+	}
+	if !errors.Is(err, auth.ErrAuthNotConfigured) && !errors.Is(err, auth.ErrRefreshTokenMissing) {
+		return "", err
+	}
+
+	usernameOrEmail, password, promptErr := s.promptCredentials()
+	if promptErr != nil {
+		return "", promptErr
+	}
+
+	accessToken, refreshToken, expiresAt, loginErr := authClient.Login(ctx, usernameOrEmail, password)
+	if loginErr != nil {
+		return "", fmt.Errorf("login failed: %w", loginErr)
+	}
+
+	state := auth.AuthState{
+		RefreshToken: refreshToken,
+		AccessToken:  accessToken,
+	}
+	if expiresAt != nil && !expiresAt.IsZero() {
+		normalized := expiresAt.UTC()
+		state.AccessTokenExpiresAt = &normalized
+	}
+	if err := auth.SaveState(state); err != nil {
+		return "", fmt.Errorf("save auth state: %w", err)
+	}
+
+	return accessToken, nil
+}
+
+func promptLoginCredentials() (string, string, error) {
+	if !term.IsTerminal(int(os.Stdin.Fd())) {
+		return "", "", fmt.Errorf("auth is not configured, run 's0c auth login' in an interactive terminal")
+	}
+
+	_, err := fmt.Fprint(os.Stderr, "Username or email: ")
+	if err != nil {
+		return "", "", err
+	}
+	reader := bufio.NewReader(os.Stdin)
+	usernameOrEmailRaw, err := reader.ReadString('\n')
+	if err != nil {
+		return "", "", fmt.Errorf("read username or email: %w", err)
+	}
+	usernameOrEmail := strings.TrimSpace(usernameOrEmailRaw)
+	if usernameOrEmail == "" {
+		return "", "", fmt.Errorf("username or email cannot be empty")
+	}
+
+	_, err = fmt.Fprint(os.Stderr, "Password: ")
+	if err != nil {
+		return "", "", err
+	}
+	passwordBytes, err := term.ReadPassword(int(os.Stdin.Fd()))
+	if err != nil {
+		return "", "", fmt.Errorf("read password: %w", err)
+	}
+	_, _ = fmt.Fprintln(os.Stderr)
+
+	password := strings.TrimSpace(string(passwordBytes))
+	if password == "" {
+		return "", "", fmt.Errorf("password cannot be empty")
+	}
+
+	return usernameOrEmail, password, nil
 }

--- a/apps/s0c/internal/auth/service.go
+++ b/apps/s0c/internal/auth/service.go
@@ -11,17 +11,22 @@ import (
 
 const accessTokenSkew = 30 * time.Second
 
+var (
+	ErrAuthNotConfigured   = errors.New("auth is not configured")
+	ErrRefreshTokenMissing = errors.New("refresh token is missing")
+)
+
 func GetValidAccessToken(ctx context.Context, refresher Refresher) (string, error) {
 	state, err := LoadState()
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return "", fmt.Errorf("auth is not configured, run 's0c auth' first")
+			return "", fmt.Errorf("%w, run 's0c auth login' first", ErrAuthNotConfigured)
 		}
 		return "", fmt.Errorf("load auth state: %w", err)
 	}
 
 	if strings.TrimSpace(state.RefreshToken) == "" {
-		return "", fmt.Errorf("refresh token is missing, run 's0c auth' first")
+		return "", fmt.Errorf("%w, run 's0c auth login' first", ErrRefreshTokenMissing)
 	}
 
 	now := time.Now()
@@ -45,12 +50,12 @@ func ForceRefreshAccessToken(ctx context.Context, refresher Refresher) (string, 
 	state, err := LoadState()
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return "", fmt.Errorf("auth is not configured, run 's0c auth' first")
+			return "", fmt.Errorf("%w, run 's0c auth login' first", ErrAuthNotConfigured)
 		}
 		return "", fmt.Errorf("load auth state: %w", err)
 	}
 	if strings.TrimSpace(state.RefreshToken) == "" {
-		return "", fmt.Errorf("refresh token is missing, run 's0c auth' first")
+		return "", fmt.Errorf("%w, run 's0c auth login' first", ErrRefreshTokenMissing)
 	}
 
 	updatedState, err := RefreshAccessToken(ctx, refresher, state)

--- a/apps/s0c/internal/auth/types.go
+++ b/apps/s0c/internal/auth/types.go
@@ -6,7 +6,7 @@ import (
 )
 
 type AuthState struct {
-	RefreshToken         string     `json:"refresh_token"`
+	RefreshToken         string     `json:"refresh_token,omitempty"`
 	AccessToken          string     `json:"access_token,omitempty"`
 	AccessTokenExpiresAt *time.Time `json:"access_token_expires_at,omitempty"`
 }

--- a/apps/s0c/internal/cli/api.go
+++ b/apps/s0c/internal/cli/api.go
@@ -124,6 +124,34 @@ func NewCmdAPIProjects() *cobra.Command {
 	}
 	cmd.Flags().Bool("pretty", false, "Pretty-print JSON response")
 
+	createCmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a project",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name, err := cmd.Flags().GetString("name")
+			if err != nil {
+				return err
+			}
+			description, err := cmd.Flags().GetString("description")
+			if err != nil {
+				return err
+			}
+
+			payload, err := platformService.CreateProject(cmd.Context(), name, description)
+			if err != nil {
+				return err
+			}
+
+			return printJSON(cmd, payload)
+		},
+	}
+	createCmd.Flags().String("name", "", "Project name")
+	createCmd.Flags().String("description", "", "Project description")
+	createCmd.Flags().Bool("pretty", false, "Pretty-print JSON response")
+	_ = createCmd.MarkFlagRequired("name")
+	cmd.AddCommand(createCmd)
+
 	return cmd
 }
 

--- a/apps/s0c/internal/cli/auth.go
+++ b/apps/s0c/internal/cli/auth.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"strings"
@@ -14,28 +15,52 @@ import (
 func NewCmdAuth() *cobra.Command {
 	authService := app.NewAuthService(S0CVersion)
 
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "auth",
-		Short: "Set auth credentials locally",
+		Short: "Authentication commands",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			_, err := fmt.Fprint(cmd.ErrOrStderr(), "Paste your sb0rka refresh token: ")
+			return cmd.Help()
+		},
+	}
+
+	loginCmd := &cobra.Command{
+		Use:   "login",
+		Short: "Log in and store local auth state",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			_, err := fmt.Fprint(cmd.ErrOrStderr(), "Username or email: ")
 			if err != nil {
 				return err
 			}
 
-			tokenBytes, err := term.ReadPassword(int(os.Stdin.Fd()))
+			reader := bufio.NewReader(cmd.InOrStdin())
+			usernameOrEmailRaw, err := reader.ReadString('\n')
 			if err != nil {
-				return fmt.Errorf("read refresh token: %w", err)
+				return fmt.Errorf("read username or email: %w", err)
+			}
+			usernameOrEmail := strings.TrimSpace(usernameOrEmailRaw)
+			if usernameOrEmail == "" {
+				return fmt.Errorf("username or email cannot be empty")
+			}
+
+			_, err = fmt.Fprint(cmd.ErrOrStderr(), "Password: ")
+			if err != nil {
+				return err
+			}
+
+			passwordBytes, err := term.ReadPassword(int(os.Stdin.Fd()))
+			if err != nil {
+				return fmt.Errorf("read password: %w", err)
 			}
 			_, _ = fmt.Fprintln(cmd.ErrOrStderr())
 
-			token := strings.TrimSpace(string(tokenBytes))
-			if token == "" {
-				return fmt.Errorf("refresh token cannot be empty")
+			password := strings.TrimSpace(string(passwordBytes))
+			if password == "" {
+				return fmt.Errorf("password cannot be empty")
 			}
 
-			if err := authService.SaveAndVerifyToken(cmd.Context(), token); err != nil {
+			if err := authService.Login(cmd.Context(), usernameOrEmail, password); err != nil {
 				return err
 			}
 
@@ -43,4 +68,23 @@ func NewCmdAuth() *cobra.Command {
 			return err
 		},
 	}
+
+	logoutCmd := &cobra.Command{
+		Use:   "logout",
+		Short: "Log out and clear local auth/config state",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := authService.Logout(cmd.Context()); err != nil {
+				return err
+			}
+
+			_, err := fmt.Fprintln(cmd.OutOrStdout(), "Logged out. Local auth and defaults were cleared.")
+			return err
+		},
+	}
+
+	cmd.AddCommand(loginCmd)
+	cmd.AddCommand(logoutCmd)
+
+	return cmd
 }

--- a/apps/s0c/internal/cli/config.go
+++ b/apps/s0c/internal/cli/config.go
@@ -11,7 +11,7 @@ import (
 func NewCmdConfig() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "config",
-		Short: "Save default project and database IDs",
+		Short: "Save defaults in local config",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if !cmd.Flags().Changed("project-id") && !cmd.Flags().Changed("database-id") {

--- a/apps/s0c/internal/cli/psql.go
+++ b/apps/s0c/internal/cli/psql.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/sb0rka/sb0rka/apps/s0c/internal/app"
 	"github.com/sb0rka/sb0rka/apps/s0c/internal/config"
@@ -26,11 +27,48 @@ func NewCmdPsql() *cobra.Command {
 				return err
 			}
 
-			projectID, err := projectIDFromFlagsOrConfig(cmd, cfg)
+			projectFlag, err := cmd.Flags().GetString("project-id")
 			if err != nil {
 				return err
 			}
-			dbID, err := databaseIDFromFlagsOrConfig(cmd, cfg)
+			databaseFlag, err := cmd.Flags().GetString("database-id")
+			if err != nil {
+				return err
+			}
+
+			projectID := strings.TrimSpace(projectFlag)
+			if projectID == "" {
+				projectID = strings.TrimSpace(cfg.ProjectID)
+			}
+			dbID := strings.TrimSpace(databaseFlag)
+			if dbID == "" {
+				dbID = strings.TrimSpace(cfg.DatabaseID)
+			}
+
+			switch {
+			case projectID == "" && dbID == "":
+				projectID, dbID, err = bootstrapPsqlDefaults(cmd, platformService, cfg)
+				if err != nil {
+					return err
+				}
+			case projectID == "" || dbID == "":
+				return fmt.Errorf("s0c is not configured with project and database defaults; use `s0c config -p <project-id> -d <database-id>`")
+			}
+
+			project, err := platformService.GetProject(cmd.Context(), projectID)
+			if err != nil {
+				return err
+			}
+			database, err := platformService.GetDatabase(cmd.Context(), projectID, dbID)
+			if err != nil {
+				return err
+			}
+
+			_, err = fmt.Fprintf(cmd.OutOrStdout(), "Operating in project %s ID: %s\n", project.Name, project.ID)
+			if err != nil {
+				return err
+			}
+			_, err = fmt.Fprintf(cmd.OutOrStdout(), "Connecting to database %s ID: %s\n", database.Name, database.ResourceID)
 			if err != nil {
 				return err
 			}
@@ -93,6 +131,43 @@ func NewCmdPsql() *cobra.Command {
 	cmd.Flags().StringP("database-id", "d", "", "Database resource ID (overrides default from `s0c config`)")
 
 	return cmd
+}
+
+func bootstrapPsqlDefaults(cmd *cobra.Command, platformService *app.PlatformService, cfg config.Config) (string, string, error) {
+	projects, err := platformService.ListProjects(cmd.Context())
+	if err != nil {
+		return "", "", fmt.Errorf("list projects: %w", err)
+	}
+	if len(projects.Projects) > 0 {
+		return "", "", fmt.Errorf("s0c is not configured with project and database defaults; use `s0c config -p <project-id> -d <database-id>`")
+	}
+
+	project, err := platformService.CreateProject(cmd.Context(), "default", "")
+	if err != nil {
+		return "", "", fmt.Errorf("create project: %w", err)
+	}
+	_, err = fmt.Fprintf(cmd.OutOrStdout(), "Created project %s ID: %s\n", project.Name, project.ID)
+	if err != nil {
+		return "", "", err
+	}
+
+	databasePayload, err := platformService.CreateDatabase(cmd.Context(), project.ID, "default_db", "")
+	if err != nil {
+		return "", "", fmt.Errorf("create database: %w", err)
+	}
+	database := databasePayload.Database
+	_, err = fmt.Fprintf(cmd.OutOrStdout(), "Created database %s ID: %s\n", database.Name, database.ResourceID)
+	if err != nil {
+		return "", "", err
+	}
+
+	cfg.ProjectID = project.ID
+	cfg.DatabaseID = database.ResourceID
+	if err := config.Save(cfg); err != nil {
+		return "", "", fmt.Errorf("save config: %w", err)
+	}
+
+	return project.ID, database.ResourceID, nil
 }
 
 func withoutPGPassword(env []string) []string {

--- a/apps/s0c/internal/client/auth.go
+++ b/apps/s0c/internal/client/auth.go
@@ -7,6 +7,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/mail"
+	"net/url"
 	"strings"
 	"time"
 
@@ -14,8 +16,77 @@ import (
 )
 
 const (
+	RouteAuthLogin          = "/auth/login"
+	RouteAuthLogout         = "/auth/logout"
 	RouteAuthSessionRefresh = "/auth/refresh"
 )
+
+type LoginResponse struct {
+	AccessToken string `json:"access_token"`
+}
+
+func (c *Client) Login(ctx context.Context, usernameOrEmail string, password string) (string, string, *time.Time, error) {
+	usernameOrEmail = strings.TrimSpace(usernameOrEmail)
+	if usernameOrEmail == "" {
+		return "", "", nil, fmt.Errorf("username or email is required")
+	}
+	password = strings.TrimSpace(password)
+	if password == "" {
+		return "", "", nil, fmt.Errorf("password is required")
+	}
+
+	form := url.Values{}
+	if looksLikeEmail(usernameOrEmail) {
+		form.Set("email", usernameOrEmail)
+	} else {
+		form.Set("username", usernameOrEmail)
+	}
+	form.Set("password", password)
+
+	respBody, httpResp, err := c.doRequest(
+		ctx,
+		http.MethodPost,
+		RouteAuthLogin,
+		strings.NewReader(form.Encode()),
+		requestOptions{
+			accept:      "application/json",
+			contentType: "application/x-www-form-urlencoded",
+		},
+	)
+	if err != nil {
+		return "", "", nil, err
+	}
+
+	var payload LoginResponse
+	if err := json.Unmarshal(respBody, &payload); err != nil {
+		return "", "", nil, fmt.Errorf("decode login response: %w", err)
+	}
+
+	access := strings.TrimSpace(payload.AccessToken)
+	if access == "" {
+		return "", "", nil, fmt.Errorf("login response did not return access token")
+	}
+
+	refreshToken := readRefreshTokenFromCookies(httpResp, c.refreshTokenCookieName)
+	if refreshToken == "" {
+		return "", "", nil, fmt.Errorf("login response did not include refresh token cookie %q", c.refreshTokenCookieName)
+	}
+
+	expiresAt, err := parseJWTAccessExp(access)
+	if err != nil {
+		return "", "", nil, err
+	}
+
+	return access, refreshToken, expiresAt, nil
+}
+
+func (c *Client) Logout(ctx context.Context, bearer string) error {
+	_, _, err := c.doRequest(ctx, http.MethodPost, RouteAuthLogout, nil, requestOptions{
+		accept: "*/*",
+		bearer: bearer,
+	})
+	return err
+}
 
 // TODO(kompotkot): Refactor this
 
@@ -23,10 +94,9 @@ func (c *Client) RefreshSession(ctx context.Context, refreshToken string) (strin
 	respBody, httpResp, err := c.doRequest(ctx, http.MethodPost, RouteAuthSessionRefresh, bytes.NewBufferString("{}"), requestOptions{
 		accept:      "application/json",
 		contentType: "application/json",
-		// TODO(kompotkot): Params from config
 		cookies: []*http.Cookie{
 			{
-				Name:  "refresh_token",
+				Name:  c.refreshTokenCookieName,
 				Value: refreshToken,
 				Path:  "/",
 			},
@@ -46,15 +116,21 @@ func (c *Client) RefreshSession(ctx context.Context, refreshToken string) (strin
 		return "", "", nil, err
 	}
 
-	nextRefreshToken := strings.TrimSpace(payload.RefreshToken)
-	for _, cookie := range httpResp.Cookies() {
-		if cookie.Name == "refresh_token" && cookie.Value != "" {
-			nextRefreshToken = cookie.Value
-			break
-		}
+	nextRefreshToken := readRefreshTokenFromCookies(httpResp, c.refreshTokenCookieName)
+	if nextRefreshToken == "" {
+		nextRefreshToken = strings.TrimSpace(payload.RefreshToken)
 	}
 
 	return payload.AccessToken, nextRefreshToken, expiresAt, nil
+}
+
+func readRefreshTokenFromCookies(httpResp *http.Response, cookieName string) string {
+	for _, cookie := range httpResp.Cookies() {
+		if cookie.Name == cookieName && cookie.Value != "" {
+			return cookie.Value
+		}
+	}
+	return ""
 }
 
 func parseExpiry(resp contract.RefreshSessionResponse) (*time.Time, error) {
@@ -98,4 +174,9 @@ func parseJWTAccessExp(accessToken string) (*time.Time, error) {
 
 	t := time.Unix(claims.Exp, 0).UTC()
 	return &t, nil
+}
+
+func looksLikeEmail(v string) bool {
+	_, err := mail.ParseAddress(v)
+	return err == nil
 }

--- a/apps/s0c/internal/client/client.go
+++ b/apps/s0c/internal/client/client.go
@@ -14,9 +14,10 @@ import (
 const defaultHTTPTimeout = 15 * time.Second
 
 type Client struct {
-	baseURL    string
-	userAgent  string
-	httpClient *http.Client
+	baseURL                string
+	userAgent              string
+	httpClient             *http.Client
+	refreshTokenCookieName string
 }
 
 type ClientOption func(*Client)
@@ -37,6 +38,15 @@ func WithTimeout(timeout time.Duration) ClientOption {
 	}
 }
 
+func WithRefreshTokenCookieName(cookieName string) ClientOption {
+	return func(c *Client) {
+		cookieName = strings.TrimSpace(cookieName)
+		if cookieName != "" {
+			c.refreshTokenCookieName = cookieName
+		}
+	}
+}
+
 type HTTPError struct {
 	StatusCode int
 	Body       string
@@ -48,8 +58,9 @@ func (e *HTTPError) Error() string {
 
 func NewClient(baseURL string, userAgent string, opts ...ClientOption) *Client {
 	client := &Client{
-		baseURL:   strings.TrimRight(strings.TrimSpace(baseURL), "/"),
-		userAgent: strings.TrimSpace(userAgent),
+		baseURL:                strings.TrimRight(strings.TrimSpace(baseURL), "/"),
+		userAgent:              strings.TrimSpace(userAgent),
+		refreshTokenCookieName: "__Secure-refresh_token",
 		httpClient: &http.Client{
 			Timeout: defaultHTTPTimeout,
 		},

--- a/apps/s0c/internal/client/platform.go
+++ b/apps/s0c/internal/client/platform.go
@@ -12,9 +12,12 @@ import (
 const (
 	RoutePlanGet        = "/plan"
 	RouteProjectList    = "/projects"
+	RouteProjectCreate  = "/projects"
+	RouteProjectGet     = "/projects/{project_id}"
 	RouteDatabaseList   = "/projects/{project_id}/databases"
 	RouteDatabaseCreate = "/projects/{project_id}/database"
-	RouteDatabaseURI    = "/projects/{project_id}/resources/{db_id}/database/uri"
+	RouteDatabaseGet    = "/projects/{project_id}/resources/{resource_id}/database"
+	RouteDatabaseURI    = "/projects/{project_id}/resources/{resource_id}/database/uri"
 )
 
 func ListProjects(ctx context.Context, client *Client, bearer string) (contract.ProjectListResponse, error) {
@@ -23,6 +26,34 @@ func ListProjects(ctx context.Context, client *Client, bearer string) (contract.
 		return contract.ProjectListResponse{}, err
 	}
 
+	return payload, nil
+}
+
+func CreateProject(ctx context.Context, client *Client, bearer string, name string, description string) (contract.ProjectResponse, error) {
+	var payload contract.ProjectResponse
+
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return contract.ProjectResponse{}, fmt.Errorf("project name is required")
+	}
+
+	reqBody := contract.CreateProjectRequest{
+		Name:        name,
+		Description: strings.TrimSpace(description),
+	}
+	if err := client.DoJSON(ctx, "POST", RouteProjectCreate, bearer, reqBody, &payload); err != nil {
+		return contract.ProjectResponse{}, err
+	}
+
+	return payload, nil
+}
+
+func GetProject(ctx context.Context, client *Client, bearer string, projectID string) (contract.ProjectResponse, error) {
+	var payload contract.ProjectResponse
+	path := routeWithProjectID(RouteProjectGet, projectID)
+	if err := client.DoJSON(ctx, "GET", path, bearer, nil, &payload); err != nil {
+		return contract.ProjectResponse{}, err
+	}
 	return payload, nil
 }
 
@@ -84,16 +115,25 @@ func CreateDatabase(
 }
 
 func GetDatabaseURI(ctx context.Context, client *Client, bearer string, projectID string, dbID string) (string, error) {
-	path := routeWithDatabaseID(RouteDatabaseURI, projectID, dbID)
+	path := routeWithResourceID(RouteDatabaseURI, projectID, dbID)
 	return client.DoText(ctx, "GET", path, bearer)
+}
+
+func GetDatabase(ctx context.Context, client *Client, bearer string, projectID string, dbID string) (contract.DatabaseResponse, error) {
+	var payload contract.DatabaseResponse
+	path := routeWithResourceID(RouteDatabaseGet, projectID, dbID)
+	if err := client.DoJSON(ctx, "GET", path, bearer, nil, &payload); err != nil {
+		return contract.DatabaseResponse{}, err
+	}
+	return payload, nil
 }
 
 func routeWithProjectID(routeTemplate string, projectID string) string {
 	return strings.ReplaceAll(routeTemplate, "{project_id}", url.PathEscape(projectID))
 }
 
-func routeWithDatabaseID(routeTemplate string, projectID string, dbID string) string {
+func routeWithResourceID(routeTemplate string, projectID string, dbID string) string {
 	path := routeWithProjectID(routeTemplate, projectID)
-	path = strings.ReplaceAll(path, "{db_id}", url.PathEscape(dbID))
+	path = strings.ReplaceAll(path, "{resource_id}", url.PathEscape(dbID))
 	return path
 }

--- a/packages/contract/database.go
+++ b/packages/contract/database.go
@@ -33,7 +33,7 @@ type UpdateDatabaseColumnRequest struct {
 }
 
 type DatabaseResponse struct {
-	ResourceID  int64   `json:"resource_id"`
+	ResourceID  string  `json:"resource_id"`
 	Name        string  `json:"name"`
 	Description *string `json:"description,omitempty"`
 	NextTableID int64   `json:"next_table_id"`

--- a/packages/contract/project.go
+++ b/packages/contract/project.go
@@ -13,7 +13,7 @@ type UpdateProjectRequest struct {
 }
 
 type ProjectResponse struct {
-	ID          int64     `json:"id"`
+	ID          string    `json:"id"`
 	UserID      string    `json:"user_id"`
 	Name        string    `json:"name"`
 	Description *string   `json:"description,omitempty"`

--- a/packages/contract/secret.go
+++ b/packages/contract/secret.go
@@ -3,7 +3,7 @@ package contract
 import "time"
 
 type SecretResponse struct {
-	ResourceID  int64      `json:"resource_id"`
+	ResourceID  string     `json:"resource_id"`
 	Name        string     `json:"name"`
 	Description *string    `json:"description,omitempty"`
 	RevealedAt  *time.Time `json:"revealed_at,omitempty"`


### PR DESCRIPTION
## Summary
- replace manual token-paste auth with `s0c auth login` using username/email + hidden password, add `s0c auth logout`, and align login/refresh/logout handling with auth cookie behavior
- add automatic psql bootstrap when both defaults are missing (create `default` project + `default_db`, persist to `~/.s0c/config.json`, print creation steps), while returning clear config errors when only partial defaults exist or projects already exist
- switch project/database/secret IDs in s0c contract usage to strings, add `api projects create`, add project/database lookup output before opening psql, and update docs/env sample accordingly