### PR TITLE
feat(auth): internal-only route seam for org endpoints

### DIFF
--- a/apps/auth/internal/store/db/db.go
+++ b/apps/auth/internal/store/db/db.go
@@ -46,7 +46,6 @@ type Database interface {
 	CreateOrganization(ctx context.Context, orgID uuid.UUID, name string, description *string, ownerUserID uuid.UUID) (model.Organization, error)
 	GetOrganization(ctx context.Context, orgID, memberUserID uuid.UUID) (model.Organization, error)
 	GetOrganizationByID(ctx context.Context, orgID uuid.UUID) (model.Organization, error)
-	ListOrganizations(ctx context.Context, userID uuid.UUID) ([]model.Organization, error)
 	UpdateOrganization(ctx context.Context, orgID, memberUserID uuid.UUID, name *string, description *string) (model.Organization, error)
 	DeleteOrganization(ctx context.Context, orgID, memberUserID uuid.UUID) error
 

--- a/apps/auth/internal/store/db/organization.go
+++ b/apps/auth/internal/store/db/organization.go
@@ -98,32 +98,6 @@ func (p *PsqlDB) GetOrganizationByID(ctx context.Context, orgID uuid.UUID) (mode
 	return org, nil
 }
 
-func (p *PsqlDB) ListOrganizations(ctx context.Context, userID uuid.UUID) ([]model.Organization, error) {
-	const query = `
-		SELECT o.id, o.name, o.description, o.created_at, o.updated_at
-		FROM organizations o
-		JOIN organization_members m ON m.organization_id = o.id
-		JOIN users u ON u.id = m.user_id AND u.is_active = true
-		WHERE m.user_id = $1
-		ORDER BY o.created_at DESC
-	`
-	rows, err := p.pool.Query(ctx, query, userID)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
-	orgs := make([]model.Organization, 0)
-	for rows.Next() {
-		var org model.Organization
-		if err := rows.Scan(&org.ID, &org.Name, &org.Description, &org.CreatedAt, &org.UpdatedAt); err != nil {
-			return nil, err
-		}
-		orgs = append(orgs, org)
-	}
-	return orgs, rows.Err()
-}
-
 func (p *PsqlDB) UpdateOrganization(ctx context.Context, orgID, memberUserID uuid.UUID, name *string, description *string) (model.Organization, error) {
 	const query = `
 		UPDATE organizations o

--- a/apps/auth/internal/transport/organizations/handlers.go
+++ b/apps/auth/internal/transport/organizations/handlers.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/sb0rka/sb0rka/apps/auth/internal/authz"
-	"github.com/sb0rka/sb0rka/apps/auth/internal/transport/runtime"
-	"github.com/sb0rka/sb0rka/apps/auth/internal/store/db"
 	"github.com/sb0rka/sb0rka/apps/auth/internal/domain/model"
+	"github.com/sb0rka/sb0rka/apps/auth/internal/store/db"
+	"github.com/sb0rka/sb0rka/apps/auth/internal/transport/runtime"
 	"github.com/sb0rka/sb0rka/packages/contract"
 )
 
@@ -133,31 +133,6 @@ func (h *Handler) assertNotLastOwner(ctx context.Context, orgID, callerID uuid.U
 		return errLastOwner
 	}
 	return nil
-}
-
-func (h *Handler) ListOrganizations(w http.ResponseWriter, r *http.Request) {
-	cID, ok := extractCallerID(w, r)
-	if !ok {
-		return
-	}
-
-	orgs, err := h.deps.Database.ListOrganizations(r.Context(), cID)
-	if err != nil {
-		if errors.Is(err, db.ErrUserNotFound) {
-			writeForbidden(w)
-			return
-		}
-		h.deps.Log.Error("list_organizations_failed", "caller_id", cID, "error", err)
-		http.Error(w, "Failed to list organizations", http.StatusInternalServerError)
-		return
-	}
-
-	out := contract.OrganizationListResponse{Organizations: make([]contract.OrganizationResponse, 0, len(orgs))}
-	for _, o := range orgs {
-		out.Organizations = append(out.Organizations, ToOrganizationResponse(o))
-	}
-	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(out)
 }
 
 func (h *Handler) CreateOrganization(w http.ResponseWriter, r *http.Request) {

--- a/apps/auth/internal/transport/router.go
+++ b/apps/auth/internal/transport/router.go
@@ -7,6 +7,7 @@ import (
 	"github.com/sb0rka/sb0rka/apps/auth/internal/transport/organizations"
 	"github.com/sb0rka/sb0rka/apps/auth/internal/transport/runtime"
 	"github.com/sb0rka/sb0rka/apps/auth/internal/transport/users"
+	"github.com/sb0rka/sb0rka/apps/auth/pkg/authhttp"
 )
 
 type Dependencies = runtime.Dependencies
@@ -51,7 +52,6 @@ func (s *Server) BuildCommonHandler() *http.Handler {
 	mux.Handle("DELETE /identity/users/current", s.authMiddleware(s.requireLiveSessionMiddleware(http.HandlerFunc(s.users.UserDelete))))
 
 	// Organization endpoints
-	mux.Handle("GET /identity/organizations", s.authMiddleware(http.HandlerFunc(s.organizations.ListOrganizations)))
 	mux.Handle("POST /identity/organizations", s.authMiddleware(s.requireLiveSessionMiddleware(http.HandlerFunc(s.organizations.CreateOrganization))))
 	mux.Handle("GET /identity/organizations/{organization_id}", s.authMiddleware(http.HandlerFunc(s.organizations.GetOrganization)))
 	mux.Handle("PATCH /identity/organizations/{organization_id}", s.authMiddleware(s.requireLiveSessionMiddleware(http.HandlerFunc(s.organizations.UpdateOrganization))))
@@ -64,9 +64,25 @@ func (s *Server) BuildCommonHandler() *http.Handler {
 	mux.Handle("PATCH /identity/organizations/{organization_id}/memberships/{user_id}", s.authMiddleware(s.requireLiveSessionMiddleware(http.HandlerFunc(s.organizations.UpdateMemberRole))))
 	mux.Handle("DELETE /identity/organizations/{organization_id}/memberships/{user_id}", s.authMiddleware(s.requireLiveSessionMiddleware(http.HandlerFunc(s.organizations.RemoveMember))))
 
+	// Routes provided by internal-only features share the same middleware stack below.
+	for _, rt := range s.deps.Routes {
+		mux.Handle(rt.Pattern, s.wrap(rt.Access, rt.Handler))
+	}
+
 	commonHandler := s.loggerMiddleware(mux)
 	commonHandler = s.corsMiddleware(commonHandler)
 	commonHandler = s.panicMiddleware(commonHandler)
 
 	return &commonHandler
+}
+
+func (s *Server) wrap(access authhttp.Access, h http.HandlerFunc) http.Handler {
+	switch access {
+	case authhttp.LiveSession:
+		return s.authMiddleware(s.requireLiveSessionMiddleware(h))
+	case authhttp.Authenticated:
+		return s.authMiddleware(h)
+	default:
+		return h
+	}
 }

--- a/apps/auth/internal/transport/runtime/deps.go
+++ b/apps/auth/internal/transport/runtime/deps.go
@@ -6,13 +6,15 @@ import (
 	"github.com/sb0rka/sb0rka/apps/auth/internal/authz"
 	"github.com/sb0rka/sb0rka/apps/auth/internal/config"
 	"github.com/sb0rka/sb0rka/apps/auth/internal/store/db"
+	"github.com/sb0rka/sb0rka/apps/auth/pkg/authhttp"
 	"github.com/sb0rka/sb0rka/apps/auth/pkg/invite"
 )
 
 type Dependencies struct {
-	Database         db.Database
-	Cfg              config.ServerConfig
-	Log              *slog.Logger
-	Authorizer       authz.Authorizer
-	InviteHook       invite.Hook
+	Database   db.Database
+	Cfg        config.ServerConfig
+	Log        *slog.Logger
+	Authorizer authz.Authorizer
+	InviteHook invite.Hook
+	Routes     []authhttp.Route
 }

--- a/apps/auth/pkg/authapp/app.go
+++ b/apps/auth/pkg/authapp/app.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sb0rka/sb0rka/apps/auth/internal/logger"
 	"github.com/sb0rka/sb0rka/apps/auth/internal/store"
 	"github.com/sb0rka/sb0rka/apps/auth/internal/transport"
+	"github.com/sb0rka/sb0rka/apps/auth/pkg/authhttp"
 	"github.com/sb0rka/sb0rka/apps/auth/pkg/invite"
 	coretransport "github.com/sb0rka/sb0rka/packages/core/transport"
 )
@@ -56,12 +57,21 @@ func (a *App) Run(ctx context.Context) error {
 		hook = a.opts.InviteHookFactory(repo)
 	}
 
+	var routes []authhttp.Route
+	for _, build := range a.opts.RouteFactories {
+		if build == nil {
+			continue
+		}
+		routes = append(routes, build(database)...)
+	}
+
 	newSrv := transport.NewServer(transport.Dependencies{
-		Database:         database,
-		Authorizer:       authz.NewRBACAuthorizer(database),
-		Cfg:              cfg.Server,
-		Log:              log,
-		InviteHook:       hook,
+		Database:   database,
+		Authorizer: authz.NewRBACAuthorizer(database),
+		Cfg:        cfg.Server,
+		Log:        log,
+		InviteHook: hook,
+		Routes:     routes,
 	})
 	handler := newSrv.BuildCommonHandler()
 	addr := fmt.Sprintf("%s:%s", cfg.Server.Addr, cfg.Server.Port)

--- a/apps/auth/pkg/authapp/options.go
+++ b/apps/auth/pkg/authapp/options.go
@@ -1,6 +1,9 @@
 package authapp
 
-import "github.com/sb0rka/sb0rka/apps/auth/pkg/invite"
+import (
+	"github.com/sb0rka/sb0rka/apps/auth/pkg/authhttp"
+	"github.com/sb0rka/sb0rka/apps/auth/pkg/invite"
+)
 
 type Options struct {
 	// InviteRepositoryFactory builds the invite repository from the auth database.
@@ -10,4 +13,6 @@ type Options struct {
 	// InviteHookFactory builds the invite hook from a repository.
 	// Nil → invite.Noop().
 	InviteHookFactory invite.HookFactory
+
+	RouteFactories []authhttp.RoutesFactory
 }

--- a/apps/auth/pkg/authctx/authctx.go
+++ b/apps/auth/pkg/authctx/authctx.go
@@ -1,0 +1,25 @@
+package authctx
+
+import (
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/sb0rka/sb0rka/apps/auth/internal/transport/runtime"
+)
+
+// ExtractCallerID mirrors the public extractCallerID for modules that can't import the internal runtime package.
+func ExtractCallerID(w http.ResponseWriter, r *http.Request) (uuid.UUID, bool) {
+	raw, ok := runtime.AuthUserIDFromContext(r.Context())
+	if !ok {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":"forbidden"}`))
+		return uuid.UUID{}, false
+	}
+	id, err := uuid.Parse(raw)
+	if err != nil {
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return uuid.UUID{}, false
+	}
+	return id, true
+}

--- a/apps/auth/pkg/authhttp/authhttp.go
+++ b/apps/auth/pkg/authhttp/authhttp.go
@@ -1,0 +1,19 @@
+package authhttp
+
+import "net/http"
+
+type Access int
+
+const (
+	Public Access = iota
+	Authenticated
+	LiveSession
+)
+
+type Route struct {
+	Pattern string // ServeMux pattern, e.g. "GET /identity/organizations"
+	Handler http.HandlerFunc
+	Access  Access
+}
+
+type RoutesFactory func(database any) []Route


### PR DESCRIPTION
## Что

Нейтральный seam для монтирования **internal-only** ручек на auth-сервер. Идея — как у invite-seam (фабрика + `Options` + no-op по умолчанию через пустой слайс), но фича отдаёт **роуты**, а не hook. Поэтому ручка живёт в internal и **в community-сборке её нет**.

Первый потребитель — `ListOrganizations`: ручка `GET /identity/organizations` и `Database.ListOrganizations` удалены из публичной сборки.

## Контракт (`pkg/authhttp`)

```go
type Access int            // Public | Authenticated | LiveSession
type Route struct { Pattern string; Handler http.HandlerFunc; Access Access }

// Одна фабрика: db (opaque) → роуты. Репозиторий/сервис фича строит внутри.
type RoutesFactory func(database any) []Route
```

- `authapp.Options.RouteFactories []authhttp.RoutesFactory` — слайс фабрик (multiplicity), вокабуляр «…Factory» как у invites.
- `app.Run()` после коннекта строит роуты: `build(database)`, кладёт в `Dependencies.Routes`.
- `BuildCommonHandler` монтирует их `mux.Handle(rt.Pattern, s.wrap(rt.Access, rt.Handler))` — `wrap` навешивает auth-цепочку по `Access`.
- `pkg/authctx.ExtractCallerID(w, r)` — публичный ридер identity для out-of-module модулей (копия публичного `extractCallerID`, т.к. ключи контекста и `runtime` не импортируются извне).

Двухступенчатую фабрику (`Repository`/`RepositoryFactory`) намеренно **не** заводим: в отличие от invites репозиторий тут не переиспользуется (нет CLI), поэтому отдельная фабрика была бы прокладкой `any → *repository` внутри одного пакета. Появится второй потребитель — выделим.

## Расширяемость

| Добавляем | Кода |
| --- | --- |
| ручку | одна `Route{}` в `RoutesFactory` |
| middleware | значение `Access` + `case` в `s.wrap` (одно место) |
| модуль | один `RoutesFactory` в `Options.RouteFactories` |

## Границы

Через границу модулей идёт только `any` + stdlib-типы. Никаких `*Server`/`Database`/middleware в публичном API; `*http.ServeMux` границу не пересекает (монтирует public). `Mount`/Toolkit намеренно нет — god-object не заводим.

## Не входит

RBAC для authz'ных org-ручек (`GetOrganization`/`AddMember`) — отдельным дизайном. `ListOrganizations` авторизации не требует (только свои организации), поэтому он первый.
