### PR TITLE
Invite requests

### DIFF
--- a/packages/contract/organization.go
+++ b/packages/contract/organization.go
@@ -52,10 +52,8 @@ type OrganizationMemberListResponse struct {
 	Members []OrganizationMemberResponse `json:"members"`
 }
 
-// OrganizationInviteResponse describes a pending or resolved organization-member
-// invite. Status is derived server-side: pending, accepted, expired, or revoked.
-// Email/Username identify the invited user and may be absent if the target user
-// was removed.
+// Status is one of: pending, accepted, expired, revoked.
+// Email/Username may be absent if the invited user was removed.
 type OrganizationInviteResponse struct {
 	ID              string     `json:"id"`
 	OrganizationID  string     `json:"organization_id"`

--- a/packages/contract/organization.go
+++ b/packages/contract/organization.go
@@ -34,6 +34,12 @@ type OrganizationMemberUpdateRequest struct {
 	Role string `json:"role"`
 }
 
+type OrganizationMemberInviteCreateRequest struct {
+	Username *string `json:"username,omitempty"`
+	Email *string `json:"email,omitempty"`
+	Role  string `json:"role"`
+}
+
 type OrganizationMemberResponse struct {
 	UserID    string    `json:"user_id"`
 	Role      string    `json:"role"`

--- a/packages/contract/organization.go
+++ b/packages/contract/organization.go
@@ -51,3 +51,23 @@ type OrganizationMemberListResponse struct {
 	ID      string                       `json:"id"`
 	Members []OrganizationMemberResponse `json:"members"`
 }
+
+// OrganizationInviteResponse describes a pending or resolved organization-member
+// invite. Status is derived server-side: pending, accepted, expired, or revoked.
+// Email/Username identify the invited user and may be absent if the target user
+// was removed.
+type OrganizationInviteResponse struct {
+	ID              string     `json:"id"`
+	OrganizationID  string     `json:"organization_id"`
+	Role            string     `json:"role"`
+	Status          string     `json:"status"`
+	Email           *string    `json:"email,omitempty"`
+	Username        *string    `json:"username,omitempty"`
+	CreatedByUserID *string    `json:"created_by_user_id,omitempty"`
+	CreatedAt       time.Time  `json:"created_at"`
+	ExpiresAt       *time.Time `json:"expires_at,omitempty"`
+}
+
+type OrganizationInviteListResponse struct {
+	Invites []OrganizationInviteResponse `json:"invites"`
+}

--- a/packages/contract/organization.go
+++ b/packages/contract/organization.go
@@ -36,8 +36,8 @@ type OrganizationMemberUpdateRequest struct {
 
 type OrganizationMemberInviteCreateRequest struct {
 	Username *string `json:"username,omitempty"`
-	Email *string `json:"email,omitempty"`
-	Role  string `json:"role"`
+	Email    *string `json:"email,omitempty"`
+	Role     string  `json:"role"`
 }
 
 type OrganizationMemberResponse struct {
@@ -54,7 +54,7 @@ type OrganizationMemberListResponse struct {
 
 // Status is one of: pending, accepted, expired, revoked.
 // Email/Username may be absent if the invited user was removed.
-type OrganizationInviteResponse struct {
+type OrganizationMemberInviteResponse struct {
 	ID              string     `json:"id"`
 	OrganizationID  string     `json:"organization_id"`
 	Role            string     `json:"role"`
@@ -66,6 +66,6 @@ type OrganizationInviteResponse struct {
 	ExpiresAt       *time.Time `json:"expires_at,omitempty"`
 }
 
-type OrganizationInviteListResponse struct {
-	Invites []OrganizationInviteResponse `json:"invites"`
+type OrganizationMemberInviteListResponse struct {
+	Invites []OrganizationMemberInviteResponse `json:"invites"`
 }


### PR DESCRIPTION
## Что это

Общие DTO для приглашений в организацию, потребляются приватным auth ([sb0rka/sb0rka-internal#7](https://github.com/sb0rka/sb0rka-internal/pull/7)).

- `OrganizationMemberInviteCreateRequest` — тело создания приглашения: `email` **или** `username` + `role`.
- `OrganizationMemberInviteResponse` — приглашение с производным `status` (`pending`/`accepted`/`expired`/`revoked`), ролью, email/username цели и таймстампами.
- `OrganizationMemberInviteListResponse` — обёртка списка.

Реализация ручек (list/accept/revoke) — во внутреннем репо. Здесь только контракт.

## Связанные

- Реализация: [sb0rka/sb0rka-internal#7](https://github.com/sb0rka/sb0rka-internal/pull/7)
- Задача: [sb0rka/project-tm#29](https://github.com/sb0rka/project-tm/issues/29)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
