### PR TITLE
fix: корректные коды ответов во всех ручках + закрытие IDOR в iam

### DIFF
--- a/apps/api/internal/openapi/docs.go
+++ b/apps/api/internal/openapi/docs.go
@@ -390,6 +390,12 @@ const docTemplate = `{
                         "schema": {
                             "type": "string"
                         }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "type": "string"
+                        }
                     }
                 }
             }
@@ -450,6 +456,12 @@ const docTemplate = `{
                     },
                     "404": {
                         "description": "Not Found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
                         "schema": {
                             "type": "string"
                         }
@@ -820,6 +832,12 @@ const docTemplate = `{
                             "type": "string"
                         }
                     },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
                     "404": {
                         "description": "Not Found",
                         "schema": {
@@ -867,6 +885,12 @@ const docTemplate = `{
                     },
                     "400": {
                         "description": "Bad Request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
                         "schema": {
                             "type": "string"
                         }
@@ -2371,6 +2395,12 @@ const docTemplate = `{
                             "type": "string"
                         }
                     },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
                     "422": {
                         "description": "Unprocessable Entity",
                         "schema": {
@@ -2509,6 +2539,12 @@ const docTemplate = `{
                     },
                     "400": {
                         "description": "Bad Request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
                         "schema": {
                             "type": "string"
                         }

--- a/apps/api/internal/openapi/swagger.json
+++ b/apps/api/internal/openapi/swagger.json
@@ -383,6 +383,12 @@
                         "schema": {
                             "type": "string"
                         }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "type": "string"
+                        }
                     }
                 }
             }
@@ -443,6 +449,12 @@
                     },
                     "404": {
                         "description": "Not Found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
                         "schema": {
                             "type": "string"
                         }
@@ -813,6 +825,12 @@
                             "type": "string"
                         }
                     },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
                     "404": {
                         "description": "Not Found",
                         "schema": {
@@ -860,6 +878,12 @@
                     },
                     "400": {
                         "description": "Bad Request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
                         "schema": {
                             "type": "string"
                         }
@@ -2364,6 +2388,12 @@
                             "type": "string"
                         }
                     },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
                     "422": {
                         "description": "Unprocessable Entity",
                         "schema": {
@@ -2502,6 +2532,12 @@
                     },
                     "400": {
                         "description": "Bad Request",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
                         "schema": {
                             "type": "string"
                         }

--- a/apps/api/internal/openapi/swagger.yaml
+++ b/apps/api/internal/openapi/swagger.yaml
@@ -740,6 +740,10 @@ paths:
           description: Not Found
           schema:
             type: string
+        "409":
+          description: Conflict
+          schema:
+            type: string
       security:
       - BearerAuth: []
       summary: Обновить метаданные проекта
@@ -778,6 +782,10 @@ paths:
             type: string
         "404":
           description: Not Found
+          schema:
+            type: string
+        "409":
+          description: Conflict
           schema:
             type: string
       security:
@@ -1012,6 +1020,10 @@ paths:
           description: Bad Request
           schema:
             type: string
+        "403":
+          description: Forbidden
+          schema:
+            type: string
         "404":
           description: Not Found
           schema:
@@ -1042,6 +1054,10 @@ paths:
             $ref: '#/definitions/contract.ProjectQuotaListResponse'
         "400":
           description: Bad Request
+          schema:
+            type: string
+        "403":
+          description: Forbidden
           schema:
             type: string
         "404":
@@ -2009,6 +2025,10 @@ paths:
           description: Not Found
           schema:
             type: string
+        "409":
+          description: Conflict
+          schema:
+            type: string
         "422":
           description: Unprocessable Entity
           schema:
@@ -2096,6 +2116,10 @@ paths:
             type: object
         "400":
           description: Bad Request
+          schema:
+            type: string
+        "403":
+          description: Forbidden
           schema:
             type: string
         "404":

--- a/apps/api/internal/store/db/errors.go
+++ b/apps/api/internal/store/db/errors.go
@@ -25,6 +25,9 @@ var (
 	ErrResourceInUse        = errors.New("resource in use")
 	ErrInvalidSecretVersion = errors.New("invalid secret version")
 
+	ErrSecretAlreadyExists   = errors.New("secret already exists")
+	ErrDatabaseAlreadyExists = errors.New("database already exists")
+
 	ErrSecretVersionAlreadyDisabled        = errors.New("secret version already disabled")
 	ErrCannotDisableCurrentSecretVersion   = errors.New("cannot disable current secret version")
 	ErrSecretVersionReferencedByDBVerifier = errors.New("secret version referenced by db verifier")

--- a/apps/api/internal/store/db/psql.go
+++ b/apps/api/internal/store/db/psql.go
@@ -173,6 +173,12 @@ func (p *PsqlDB) EnsureSubjectPlan(ctx context.Context, subjectID uuid.UUID, pla
 		VALUES ($1, $2)
 	`
 	if _, err := p.pool.Exec(ctx, insertQuery, subjectID, planID); err != nil {
+		// Конкурентный init мог вставить план между SELECT и INSERT — операция
+		// идемпотентна, гонка на pk_subject_plans не ошибка.
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			return nil
+		}
 		return err
 	}
 
@@ -663,6 +669,10 @@ func (p *PsqlDB) UpdateProject(ctx context.Context, id string, name *string, des
 		if errors.Is(err, pgx.ErrNoRows) {
 			return model.Project{}, ErrProjectNotFound
 		}
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			return model.Project{}, ErrProjectAlreadyExists
+		}
 		return model.Project{}, err
 	}
 	return project, nil
@@ -1028,6 +1038,10 @@ func (p *PsqlDB) CreateDatabase(ctx context.Context, params CreateDatabaseParams
 		&dbRow.DesiredRuntimeState,
 		&dbRow.Description,
 	); err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			return model.DBInstance{}, model.Secret{}, model.SecretVersion{}, ErrDatabaseAlreadyExists
+		}
 		return model.DBInstance{}, model.Secret{}, model.SecretVersion{}, err
 	}
 
@@ -1511,6 +1525,10 @@ func (p *PsqlDB) CreateSecretWithInitialVersion(ctx context.Context, params Crea
 		&secret.UpdatedAt,
 		&secret.ScheduledDestroyAt,
 	); err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			return model.Secret{}, model.SecretVersion{}, ErrSecretAlreadyExists
+		}
 		return model.Secret{}, model.SecretVersion{}, err
 	}
 

--- a/apps/api/internal/transport/dbis/handlers.go
+++ b/apps/api/internal/transport/dbis/handlers.go
@@ -76,6 +76,7 @@ func (h *Handler) authorize(w http.ResponseWriter, r *http.Request, callerID uui
 // @Failure  400         {string}  string
 // @Failure  403         {string}  string
 // @Failure  404         {string}  string
+// @Failure  409         {string}  string
 // @Security BearerAuth
 // @Router   /projects/{project_id}/dbi [post]
 func (h *Handler) CreateDBInstance(w http.ResponseWriter, r *http.Request) {
@@ -187,6 +188,10 @@ func (h *Handler) CreateDBInstance(w http.ResponseWriter, r *http.Request) {
 		EncryptedMessage:      encryptedSecretValue,
 	})
 	if err != nil {
+		if errors.Is(err, db.ErrDatabaseAlreadyExists) {
+			http.Error(w, "Database with this name already exists", http.StatusConflict)
+			return
+		}
 		h.deps.Log.Error("create_database_failed", "error", err)
 		http.Error(w, "Failed to create database", http.StatusInternalServerError)
 		return

--- a/apps/api/internal/transport/iam/handlers.go
+++ b/apps/api/internal/transport/iam/handlers.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/sb0rka/sb0rka/apps/api/internal/authz"
 	"github.com/sb0rka/sb0rka/apps/api/internal/domain/model"
 	"github.com/sb0rka/sb0rka/apps/api/internal/store/db"
 	"github.com/sb0rka/sb0rka/apps/api/internal/transport/runtime"
@@ -21,6 +22,35 @@ type Handler struct {
 
 func NewHandler(deps runtime.Dependencies) *Handler {
 	return &Handler{deps: deps}
+}
+
+func (h *Handler) authorizeProjectRead(w http.ResponseWriter, r *http.Request, projectID string) bool {
+	subjectIDStr, ok := authctx.SubjectIDFromContext(r.Context())
+	if !ok {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return false
+	}
+	subjectID, err := uuid.Parse(strings.TrimSpace(subjectIDStr))
+	if err != nil {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return false
+	}
+	decision, err := h.deps.Authorizer.Authorize(r.Context(), subjectID, authz.ActionProjectRead, authz.ResourceRef{
+		Type: "project",
+		ID:   projectID,
+	})
+	if err != nil {
+		h.deps.Log.Error("authorize_failed", "action", authz.ActionProjectRead, "project_id", projectID, "error", err)
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return false
+	}
+	if !decision.Allowed {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":"forbidden"}`))
+		return false
+	}
+	return true
 }
 
 // InitializeAccount godoc
@@ -52,7 +82,7 @@ func (h *Handler) InitializeAccount(w http.ResponseWriter, r *http.Request) {
 
 	subjectID, err := uuid.Parse(strings.TrimSpace(subjectIDStr))
 	if err != nil {
-		http.Error(w, "invalid subject_id", http.StatusInternalServerError)
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
 		return
 	}
 
@@ -84,7 +114,7 @@ func (h *Handler) GetAccountPlan(w http.ResponseWriter, r *http.Request) {
 
 	subjectID, err := uuid.Parse(strings.TrimSpace(subjectIDStr))
 	if err != nil {
-		http.Error(w, "invalid subject_id", http.StatusInternalServerError)
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
 		return
 	}
 
@@ -137,6 +167,7 @@ func (h *Handler) ListPublicPlans(w http.ResponseWriter, r *http.Request) {
 // @Param    project_id  path      string  true  "ID проекта"
 // @Success  200         {object}  contract.PlanResponse
 // @Failure  400         {string}  string
+// @Failure  403         {string}  string
 // @Failure  404         {string}  string
 // @Failure  500         {string}  string
 // @Security BearerAuth
@@ -145,6 +176,9 @@ func (h *Handler) GetProjectPlan(w http.ResponseWriter, r *http.Request) {
 	projectID := strings.TrimSpace(r.PathValue("project_id"))
 	if projectID == "" {
 		http.Error(w, "project_id is required", http.StatusBadRequest)
+		return
+	}
+	if !h.authorizeProjectRead(w, r, projectID) {
 		return
 	}
 
@@ -171,6 +205,7 @@ func (h *Handler) GetProjectPlan(w http.ResponseWriter, r *http.Request) {
 // @Param    project_id  path      string  true  "ID проекта"
 // @Success  200         {object}  contract.ProjectQuotaListResponse
 // @Failure  400         {string}  string
+// @Failure  403         {string}  string
 // @Failure  404         {string}  string
 // @Failure  500         {string}  string
 // @Security BearerAuth
@@ -179,6 +214,9 @@ func (h *Handler) GetProjectQuotas(w http.ResponseWriter, r *http.Request) {
 	projectID := strings.TrimSpace(r.PathValue("project_id"))
 	if projectID == "" {
 		http.Error(w, "project_id is required", http.StatusBadRequest)
+		return
+	}
+	if !h.authorizeProjectRead(w, r, projectID) {
 		return
 	}
 	quotas, err := h.deps.PlatformDatabase.ListProjectQuotas(r.Context(), projectID)
@@ -223,6 +261,7 @@ func (h *Handler) GetProjectQuotas(w http.ResponseWriter, r *http.Request) {
 // @Param    project_id  path      string  true  "ID проекта"
 // @Success  200         {object}  map[string]interface{}
 // @Failure  400         {string}  string
+// @Failure  403         {string}  string
 // @Failure  404         {string}  string
 // @Failure  500         {string}  string
 // @Security BearerAuth
@@ -231,6 +270,9 @@ func (h *Handler) GetProjectUsage(w http.ResponseWriter, r *http.Request) {
 	projectID := strings.TrimSpace(r.PathValue("project_id"))
 	if projectID == "" {
 		http.Error(w, "project_id is required", http.StatusBadRequest)
+		return
+	}
+	if !h.authorizeProjectRead(w, r, projectID) {
 		return
 	}
 	usage, err := h.deps.PlatformDatabase.ListProjectUsage(r.Context(), projectID)

--- a/apps/api/internal/transport/iam/handlers.go
+++ b/apps/api/internal/transport/iam/handlers.go
@@ -24,23 +24,25 @@ func NewHandler(deps runtime.Dependencies) *Handler {
 	return &Handler{deps: deps}
 }
 
-func (h *Handler) authorizeProjectRead(w http.ResponseWriter, r *http.Request, projectID string) bool {
-	subjectIDStr, ok := authctx.SubjectIDFromContext(r.Context())
+func parseSubjectID(r *http.Request) (uuid.UUID, bool) {
+	raw, ok := authctx.SubjectIDFromContext(r.Context())
 	if !ok {
-		http.Error(w, "Unauthorized", http.StatusUnauthorized)
-		return false
+		return uuid.Nil, false
 	}
-	subjectID, err := uuid.Parse(strings.TrimSpace(subjectIDStr))
+	id, err := uuid.Parse(strings.TrimSpace(raw))
 	if err != nil {
-		http.Error(w, "Unauthorized", http.StatusUnauthorized)
-		return false
+		return uuid.Nil, false
 	}
-	decision, err := h.deps.Authorizer.Authorize(r.Context(), subjectID, authz.ActionProjectRead, authz.ResourceRef{
+	return id, true
+}
+
+func (h *Handler) authorize(w http.ResponseWriter, r *http.Request, callerID uuid.UUID, action authz.Action, projectID string) bool {
+	decision, err := h.deps.Authorizer.Authorize(r.Context(), callerID, action, authz.ResourceRef{
 		Type: "project",
 		ID:   projectID,
 	})
 	if err != nil {
-		h.deps.Log.Error("authorize_failed", "action", authz.ActionProjectRead, "project_id", projectID, "error", err)
+		h.deps.Log.Error("authorize_failed", "action", action, "project_id", projectID, "error", err)
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
 		return false
 	}
@@ -64,7 +66,7 @@ func (h *Handler) authorizeProjectRead(w http.ResponseWriter, r *http.Request, p
 // @Security BearerAuth
 // @Router   /account/initialize [post]
 func (h *Handler) InitializeAccount(w http.ResponseWriter, r *http.Request) {
-	subjectIDStr, ok := authctx.SubjectIDFromContext(r.Context())
+	subjectID, ok := parseSubjectID(r)
 	if !ok {
 		http.Error(w, "Unauthorized", http.StatusUnauthorized)
 		return
@@ -77,12 +79,6 @@ func (h *Handler) InitializeAccount(w http.ResponseWriter, r *http.Request) {
 	}
 	if strings.TrimSpace(subjectKind) != "user" {
 		http.Error(w, "Forbidden", http.StatusForbidden)
-		return
-	}
-
-	subjectID, err := uuid.Parse(strings.TrimSpace(subjectIDStr))
-	if err != nil {
-		http.Error(w, "Unauthorized", http.StatusUnauthorized)
 		return
 	}
 
@@ -106,14 +102,8 @@ func (h *Handler) InitializeAccount(w http.ResponseWriter, r *http.Request) {
 // @Router   /plan [get]
 // @Router   /account/plan [get]
 func (h *Handler) GetAccountPlan(w http.ResponseWriter, r *http.Request) {
-	subjectIDStr, ok := authctx.SubjectIDFromContext(r.Context())
+	subjectID, ok := parseSubjectID(r)
 	if !ok {
-		http.Error(w, "Unauthorized", http.StatusUnauthorized)
-		return
-	}
-
-	subjectID, err := uuid.Parse(strings.TrimSpace(subjectIDStr))
-	if err != nil {
 		http.Error(w, "Unauthorized", http.StatusUnauthorized)
 		return
 	}
@@ -173,12 +163,17 @@ func (h *Handler) ListPublicPlans(w http.ResponseWriter, r *http.Request) {
 // @Security BearerAuth
 // @Router   /projects/{project_id}/plan [get]
 func (h *Handler) GetProjectPlan(w http.ResponseWriter, r *http.Request) {
+	subjectID, ok := parseSubjectID(r)
+	if !ok {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
 	projectID := strings.TrimSpace(r.PathValue("project_id"))
 	if projectID == "" {
 		http.Error(w, "project_id is required", http.StatusBadRequest)
 		return
 	}
-	if !h.authorizeProjectRead(w, r, projectID) {
+	if !h.authorize(w, r, subjectID, authz.ActionProjectRead, projectID) {
 		return
 	}
 
@@ -211,12 +206,17 @@ func (h *Handler) GetProjectPlan(w http.ResponseWriter, r *http.Request) {
 // @Security BearerAuth
 // @Router   /projects/{project_id}/quotas [get]
 func (h *Handler) GetProjectQuotas(w http.ResponseWriter, r *http.Request) {
+	subjectID, ok := parseSubjectID(r)
+	if !ok {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
 	projectID := strings.TrimSpace(r.PathValue("project_id"))
 	if projectID == "" {
 		http.Error(w, "project_id is required", http.StatusBadRequest)
 		return
 	}
-	if !h.authorizeProjectRead(w, r, projectID) {
+	if !h.authorize(w, r, subjectID, authz.ActionProjectRead, projectID) {
 		return
 	}
 	quotas, err := h.deps.PlatformDatabase.ListProjectQuotas(r.Context(), projectID)
@@ -267,12 +267,17 @@ func (h *Handler) GetProjectQuotas(w http.ResponseWriter, r *http.Request) {
 // @Security BearerAuth
 // @Router   /projects/{project_id}/usage [get]
 func (h *Handler) GetProjectUsage(w http.ResponseWriter, r *http.Request) {
+	subjectID, ok := parseSubjectID(r)
+	if !ok {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
 	projectID := strings.TrimSpace(r.PathValue("project_id"))
 	if projectID == "" {
 		http.Error(w, "project_id is required", http.StatusBadRequest)
 		return
 	}
-	if !h.authorizeProjectRead(w, r, projectID) {
+	if !h.authorize(w, r, subjectID, authz.ActionProjectRead, projectID) {
 		return
 	}
 	usage, err := h.deps.PlatformDatabase.ListProjectUsage(r.Context(), projectID)

--- a/apps/api/internal/transport/projects/handlers.go
+++ b/apps/api/internal/transport/projects/handlers.go
@@ -292,6 +292,7 @@ func (h *Handler) ListProjects(w http.ResponseWriter, r *http.Request) {
 // @Failure  400         {string}  string
 // @Failure  403         {string}  string
 // @Failure  404         {string}  string
+// @Failure  409         {string}  string
 // @Security BearerAuth
 // @Router   /projects/{project_id} [patch]
 func (h *Handler) UpdateProject(w http.ResponseWriter, r *http.Request) {
@@ -344,6 +345,10 @@ func (h *Handler) UpdateProject(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		if errors.Is(err, db.ErrProjectNotFound) {
 			http.Error(w, "Project not found", http.StatusNotFound)
+			return
+		}
+		if errors.Is(err, db.ErrProjectAlreadyExists) {
+			http.Error(w, "Project with this name already exists", http.StatusConflict)
 			return
 		}
 		h.deps.Log.Error("update_project_failed", "error", err)

--- a/apps/api/internal/transport/secrets/handlers.go
+++ b/apps/api/internal/transport/secrets/handlers.go
@@ -113,6 +113,7 @@ func (h *Handler) encryptSecretValue(r *http.Request, projectID string, secretID
 // @Failure  400         {string}  string
 // @Failure  403         {string}  string
 // @Failure  404         {string}  string
+// @Failure  409         {string}  string
 // @Failure  422         {string}  string
 // @Security BearerAuth
 // @Router   /projects/{project_id}/secret [post]
@@ -202,6 +203,10 @@ func (h *Handler) CreateSecret(w http.ResponseWriter, r *http.Request) {
 		EncryptedMessage:      encryptedMessage,
 	})
 	if err != nil {
+		if errors.Is(err, db.ErrSecretAlreadyExists) {
+			http.Error(w, "Secret with this name already exists", http.StatusConflict)
+			return
+		}
 		h.deps.Log.Error("create_secret_failed", "project_id", projectID, "secret_id", secretID, "error", err)
 		http.Error(w, "Failed to create secret", http.StatusInternalServerError)
 		return
@@ -665,7 +670,7 @@ func (h *Handler) ApplySecretVersionPasswordVerifier(w http.ResponseWriter, r *h
 		return
 	}
 	if !isDBPasswordSecret {
-		http.Error(w, "Secret is not a database password secret", http.StatusConflict)
+		http.Error(w, "Secret is not a database password secret", http.StatusUnprocessableEntity)
 		return
 	}
 	secret, version, material, err := h.deps.PlatformDatabase.GetSecretMaterialForReveal(r.Context(), projectID, secretID, versionNo)
@@ -689,7 +694,7 @@ func (h *Handler) ApplySecretVersionPasswordVerifier(w http.ResponseWriter, r *h
 	plain, err := h.deps.SecretCrypto.Decrypt(r.Context(), material.EncryptedMessage, aad, material.EncryptionKeyRef)
 	if err != nil {
 		h.deps.Log.Error("decrypt_secret_failed", "project_id", projectID, "secret_id", secretID, "version_no", versionNo, "crypto_provider", material.CryptoProvider, "encryption_key_id", material.EncryptionKeyID, "error", err)
-		http.Error(w, "secret_decrypt_failed", http.StatusInternalServerError)
+		http.Error(w, "Failed to decrypt secret value", http.StatusInternalServerError)
 		return
 	}
 	passwordVerifier, err := service.GeneratePostgresSCRAMSHA256Verifier(string(plain))
@@ -731,7 +736,7 @@ func (h *Handler) revealSecretVersion(w http.ResponseWriter, r *http.Request, pr
 	value, err := h.deps.SecretCrypto.Decrypt(r.Context(), material.EncryptedMessage, aad, material.EncryptionKeyRef)
 	if err != nil {
 		h.deps.Log.Error("decrypt_secret_failed", "project_id", projectID, "secret_id", secretID, "version_no", versionNo, "crypto_provider", material.CryptoProvider, "encryption_key_id", material.EncryptionKeyID, "error", err)
-		http.Error(w, "secret_decrypt_failed", http.StatusInternalServerError)
+		http.Error(w, "Failed to decrypt secret value", http.StatusInternalServerError)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -805,8 +810,10 @@ func (h *Handler) writeSecretStoreError(w http.ResponseWriter, event string, pro
 			http.Error(w, "Cannot disable current secret version", http.StatusConflict)
 		case errors.Is(err, db.ErrSecretVersionReferencedByDBVerifier):
 			http.Error(w, "Secret version is referenced by a database password verifier", http.StatusConflict)
+		case errors.Is(err, db.ErrResourceInUse):
+			http.Error(w, "Secret is in use by a database", http.StatusConflict)
 		default:
-			http.Error(w, "Secret conflict", http.StatusConflict)
+			http.Error(w, "Secret version conflict", http.StatusConflict)
 		}
 	case errors.Is(err, db.ErrEncryptionKeyNotFound):
 		http.Error(w, "Encryption key not found", http.StatusInternalServerError)

--- a/apps/auth/internal/service/service.go
+++ b/apps/auth/internal/service/service.go
@@ -66,12 +66,14 @@ func ValidatePhone(phoneRaw string, isPhoneRequired bool) (int, error) {
 		phone = phone[1:]
 	}
 
-	phoneNumber, err := strconv.Atoi(phone)
+	// Колонка phone — INTEGER (макс 2147483647); парсим в те же 32 бита, чтобы
+	// слишком большой номер отсеялся валидацией (400), а не упал INSERT'ом (500).
+	phoneNumber, err := strconv.ParseInt(phone, 10, 32)
 	if err != nil {
-		return 0, fmt.Errorf("failed to convert phone to number: %w", err)
+		return 0, fmt.Errorf("phone must be a number within the allowed range")
 	}
 
-	return phoneNumber, nil
+	return int(phoneNumber), nil
 }
 
 // HashPassword securely hashes a password using Argon2 algorithm

--- a/apps/auth/internal/transport/auth/handlers.go
+++ b/apps/auth/internal/transport/auth/handlers.go
@@ -78,7 +78,7 @@ func (h *Handler) AuthLogin(w http.ResponseWriter, r *http.Request) {
 	user, err := h.deps.Database.GetUser(r.Context(), "", username, email)
 	if err != nil {
 		if errors.Is(err, db.ErrUserNotFound) {
-			http.Error(w, "User not found", http.StatusNotFound)
+			http.Error(w, "Invalid credentials", http.StatusUnauthorized)
 			return
 		}
 		h.deps.Log.Error("login_get_user_failed", "error", err)
@@ -87,7 +87,7 @@ func (h *Handler) AuthLogin(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if !user.IsActive {
-		http.Error(w, "User is not active", http.StatusUnauthorized)
+		http.Error(w, "Invalid credentials", http.StatusUnauthorized)
 		return
 	}
 
@@ -165,7 +165,7 @@ func (h *Handler) AuthLogin(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) AuthRefresh(w http.ResponseWriter, r *http.Request) {
 	cookie, err := r.Cookie(h.deps.Cfg.AuthConfig.RefreshTokenCookieName)
 	if err != nil {
-		http.Error(w, "missing refresh token", http.StatusUnauthorized)
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
 		return
 	}
 
@@ -173,7 +173,7 @@ func (h *Handler) AuthRefresh(w http.ResponseWriter, r *http.Request) {
 
 	refreshToken, err := service.ValidateLengthOfRefreshToken(cookie.Value, h.deps.Cfg.AuthConfig)
 	if err != nil {
-		http.Error(w, "invalid refresh token", http.StatusUnauthorized)
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
 		return
 	}
 

--- a/apps/auth/internal/transport/users/handlers.go
+++ b/apps/auth/internal/transport/users/handlers.go
@@ -88,7 +88,7 @@ func (h *Handler) RegisterUser(w http.ResponseWriter, r *http.Request) {
 	user, err := h.deps.Database.CreateUser(r.Context(), userID, true, username, email, passwordHash, phone, postInsert)
 	if err != nil {
 		if errors.Is(err, db.ErrUserAlreadyExists) {
-			http.Error(w, "Username or email already exists", http.StatusConflict)
+			http.Error(w, "Username, email or phone already exists", http.StatusConflict)
 			return
 		}
 		h.writeHookError(w, err)
@@ -208,7 +208,7 @@ func (h *Handler) UserPatch(w http.ResponseWriter, r *http.Request) {
 	updatedUser, err := h.deps.Database.UpdateUser(r.Context(), currentUser.ID, username, email, phoneValue)
 	if err != nil {
 		if errors.Is(err, db.ErrUserAlreadyExists) {
-			http.Error(w, "Username or email already exists", http.StatusConflict)
+			http.Error(w, "Username, email or phone already exists", http.StatusConflict)
 			return
 		}
 		if errors.Is(err, db.ErrUserNotFound) {

--- a/go.work.sum
+++ b/go.work.sum
@@ -1,12 +1,10 @@
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
-github.com/cpuguy83/go-md2man/v2 v2.0.6 h1:XJtiaUW6dEEqVuZiMTn1ldk455QWwEIsMIJlo5vtkx0=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/jackc/pgx/v5 v5.7.6/go.mod h1:aruU7o91Tc2q2cFp5h4uP3f6ztExVpyVv88Xl/8Vl8M=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
-github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/sb0rka/sb0rka/packages/contract v0.0.1/go.mod h1:mRicMHPx5t59AVnV/kKuOmjuXX5IaCLPfYeLiufBxzs=
 github.com/sb0rka/sb0rka/packages/contract v0.0.4/go.mod h1:mRicMHPx5t59AVnV/kKuOmjuXX5IaCLPfYeLiufBxzs=
 github.com/sb0rka/sb0rka/packages/contract v0.0.8/go.mod h1:mRicMHPx5t59AVnV/kKuOmjuXX5IaCLPfYeLiufBxzs=
@@ -17,7 +15,6 @@ github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/urfave/cli/v2 v2.3.0 h1:qph92Y649prgesehzOrQjdWyxFOp/QVM+6imKHad91M=
 github.com/urfave/cli/v2 v2.3.0/go.mod h1:LJmUH05zAU44vOAcrfzZQKsZbVcdbOG8rtL3/XcUArI=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
@@ -113,5 +110,4 @@ golang.org/x/tools v0.35.0/go.mod h1:NKdj5HkL/73byiZSJjqJgKn3ep7KjFkBOkR/Hps3VPw
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
-sigs.k8s.io/yaml v1.3.0 h1:a2VclLzOGrwOHDiV8EfBGhvjHvP46CtW5j6POvhYGGo=
 sigs.k8s.io/yaml v1.3.0/go.mod h1:GeOyir5tyXNByN85N/dRIT9es5UQNerPYEKK56eTBm8=

--- a/go.work.sum
+++ b/go.work.sum
@@ -1,10 +1,12 @@
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
+github.com/cpuguy83/go-md2man/v2 v2.0.6 h1:XJtiaUW6dEEqVuZiMTn1ldk455QWwEIsMIJlo5vtkx0=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/jackc/pgx/v5 v5.7.6/go.mod h1:aruU7o91Tc2q2cFp5h4uP3f6ztExVpyVv88Xl/8Vl8M=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
+github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/sb0rka/sb0rka/packages/contract v0.0.1/go.mod h1:mRicMHPx5t59AVnV/kKuOmjuXX5IaCLPfYeLiufBxzs=
 github.com/sb0rka/sb0rka/packages/contract v0.0.4/go.mod h1:mRicMHPx5t59AVnV/kKuOmjuXX5IaCLPfYeLiufBxzs=
 github.com/sb0rka/sb0rka/packages/contract v0.0.8/go.mod h1:mRicMHPx5t59AVnV/kKuOmjuXX5IaCLPfYeLiufBxzs=
@@ -15,6 +17,7 @@ github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/urfave/cli/v2 v2.3.0 h1:qph92Y649prgesehzOrQjdWyxFOp/QVM+6imKHad91M=
 github.com/urfave/cli/v2 v2.3.0/go.mod h1:LJmUH05zAU44vOAcrfzZQKsZbVcdbOG8rtL3/XcUArI=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
@@ -110,4 +113,5 @@ golang.org/x/tools v0.35.0/go.mod h1:NKdj5HkL/73byiZSJjqJgKn3ep7KjFkBOkR/Hps3VPw
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
+sigs.k8s.io/yaml v1.3.0 h1:a2VclLzOGrwOHDiV8EfBGhvjHvP46CtW5j6POvhYGGo=
 sigs.k8s.io/yaml v1.3.0/go.mod h1:GeOyir5tyXNByN85N/dRIT9es5UQNerPYEKK56eTBm8=


### PR DESCRIPTION
Сплошной аудит **всех веток ошибок** обоих публичных сервисов (api — 264 ветки, auth — 102): каждая сверена с конвенцией платформы, каждая 500-ветка прослежена до метода стора на предмет «может ли туда дойти пользовательский констрейнт». Найденное исправлено, остальное подтверждено корректным.

Три коммита: security-фикс отдельно, маппинг ошибок отдельно, регенерация спеки отдельно.

## 1. IDOR в project-scoped ручках iam

`GET /projects/{id}/plan`, `/quotas`, `/usage` **не вызывали авторизатор вообще** — `iam.Handler` не трогал `deps.Authorizer`. Любой аутентифицированный пользователь читал тариф, квоты и потребление **чужого** проекта, зная его id; ответ 404 дополнительно раскрывал существование чужих проектов.

Добавлена проверка `ActionProjectRead` по образцу `resources.ListResources`. Заодно кривой `sub` в токене больше не даёт 500 — это невалидный токен, то есть 401, как во всех остальных хендлерах.

## 2. 500 вместо 4xx на пользовательских ошибках

Стор возвращал сырую ошибку pg, хендлер ловил её `default`-веткой — нарушение констрейнта становилось 500. Переведено в sentinel + 409:

| ручка | было | стало |
|---|---|---|
| `POST /projects/{id}/secret` — занятое имя | **500** | 409 |
| `POST /projects/{id}/dbi` — занятое имя | **500** | 409 |
| `PATCH /projects/{id}` — переименование в занятое | **500** | 409 |

Остальное из аудита:
- **Телефон**: 10–15 цифр не помещались в колонку `INTEGER` и валились на INSERT (`22003` → 500). Теперь диапазон ловится валидацией → 400. Настоящее решение — расширить колонку до `BIGINT`, но это миграция в repo `database` (заведена отдельно).
- **`POST /account/initialize`**: гонка на `pk_subject_plans` при конкурентных вызовах давала 500, хотя ручка идемпотентна по смыслу — дубль-вставка больше не ошибка.
- **Verifier не-парольного секрета**: 409 → **422**. Тело валидно, невалидна семантика; рядом та же ситуация с `payload_kind` уже отдаёт 422.
- **Логин**: несуществующий/деактивированный пользователь отвечал `404 User not found`, а неверный пароль — `401`. Теперь оба `401 Invalid credentials` — существование аккаунта не раскрываем.

**Сообщения**: убран машинный `secret_decrypt_failed`; конфликт при удалении секрета больше не безликий `Secret conflict`; дубликат пользователя упоминает phone (на него тоже есть unique); `/auth/refresh` отвечает единообразным `Unauthorized` вместо строчных `missing refresh token`.

## 3. Регенерация OpenAPI

Спека собирается из swaggo-аннотаций и коммитится, поэтому после добавления `@Failure 409/403` обновлена через `task swagger`. Диф — **только новые статусы**, +96 строк, постороннего дрейфа нет.

## Проверено

- **Потребители не сломаны.** Сигнатур не менял. У каждого изменённого метода стора ровно один потребитель, все обновлены (`CreateSecretWithInitialVersion`→secrets, `CreateDatabase`→dbis, `UpdateProject`→projects, `EnsureSubjectPlan`→iam, `ValidatePhone`→users×2).
- **HTTP-клиенты не сломаны.** Консоль ветвится только на 401/204, `s0c` — только на 401; на 404/409/422 логики нет. Логин зовётся с `auth: false` (`features/auth/api.ts`), поэтому смена 404→401 не триггерит refresh-интерцептор.
- `go build` и `go vet` по api и auth чистые.
- E2E-прогон на локально собранных образах зелёный. Парный PR с тестами: [sb0rka/tests#2](https://github.com/sb0rka/tests/pull/2) (до этих правок он красный — тесты сначала воспроизводят баги). Internal-часть: [sb0rka-internal#10](https://github.com/sb0rka/sb0rka-internal/pull/10).

## Осознанно НЕ трогал

- **401 vs 403 для non-user субъекта** в `/identity/users/*`: недостижимо, пока в схеме `CHECK kind IN ('user')`. Forward-looking, требует продуктового решения.
- **Timing-oracle логина**: статус и тело для несуществующего и для неверного пароля теперь идентичны, но Argon2 для отсутствующего пользователя не считается — время ответа отличается. Закрывается dummy-hash'ем; это hardening за рамками «кодов и сообщений».
- **`plan_id` в `POST /projects`**: поле принимается, но стор его игнорирует и всегда ставит `free_project`. Не пропущенная валидация, а нереализованный выбор плана — продуктовое решение.

## Честно о покрытии

Все 366 веток ошибок в этих двух сервисах прочитаны и оценены аудитом, но живым тестом подтверждена меньшая часть (в сумме по трём зонам — 62 негативных ассерта из 432 веток, ~14%). Этот PR закрывает найденное аудитом; полное покрытие каждой ветки тестом — отдельная большая итерация.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
