### PR TITLE
feat(core): HTTP-middleware в общий пакет

### DIFF
--- a/packages/core/go.mod
+++ b/packages/core/go.mod
@@ -5,6 +5,7 @@ go 1.25.5
 require github.com/jackc/pgx/v5 v5.9.2
 
 require (
+	github.com/golang-jwt/jwt/v5 v5.3.0
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect

--- a/packages/core/go.sum
+++ b/packages/core/go.sum
@@ -1,6 +1,8 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/golang-jwt/jwt/v5 v5.3.0 h1:pv4AsKCKKZuqlgs5sUmn4x8UlGa0kEVt/puTpKx9vvo=
+github.com/golang-jwt/jwt/v5 v5.3.0/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=

--- a/packages/core/transport/auth.go
+++ b/packages/core/transport/auth.go
@@ -1,0 +1,128 @@
+package transport
+
+import (
+	"crypto/ed25519"
+	"net/http"
+	"strings"
+
+	"github.com/golang-jwt/jwt/v5"
+
+	"github.com/sb0rka/sb0rka/packages/core/transport/authctx"
+)
+
+// AuthConfig — то, чем проверяется access-токен платформы. Сервисы токены
+// только проверяют, поэтому здесь публичный ключ: приватный верификатору
+// не нужен.
+//
+// Issuer, Audience, Kid и Typ проверяются только если заданы: пустое значение
+// в jwt.WithIssuer требует пустого поля в токене, то есть отклоняет всё.
+type AuthConfig struct {
+	PublicKey ed25519.PublicKey
+	Issuer    string
+	Audience  string
+	Kid       string
+	Typ       string
+}
+
+// accessTokenClaims — формат токена платформы.
+type accessTokenClaims struct {
+	SessionID   string `json:"sid"`
+	SubjectKind string `json:"sk"`
+	jwt.RegisteredClaims
+}
+
+// ParseAndVerifyAccessToken разбирает токен и возвращает личность.
+// Причина отказа наружу не уходит — она одинаковая для клиента и разная
+// только в логе.
+func ParseAndVerifyAccessToken(raw string, cfg AuthConfig) (authctx.Identity, bool) {
+	if len(cfg.PublicKey) == 0 {
+		return authctx.Identity{}, false
+	}
+
+	opts := []jwt.ParserOption{
+		jwt.WithValidMethods([]string{jwt.SigningMethodEdDSA.Alg()}),
+		jwt.WithExpirationRequired(),
+	}
+	if cfg.Issuer != "" {
+		opts = append(opts, jwt.WithIssuer(cfg.Issuer))
+	}
+	if cfg.Audience != "" {
+		opts = append(opts, jwt.WithAudience(cfg.Audience))
+	}
+
+	claims := &accessTokenClaims{}
+	_, err := jwt.ParseWithClaims(raw, claims, func(token *jwt.Token) (any, error) {
+		if cfg.Kid != "" {
+			kid, _ := token.Header["kid"].(string)
+			if kid != cfg.Kid {
+				return nil, jwt.ErrTokenUnverifiable
+			}
+		}
+		if cfg.Typ != "" {
+			typ, _ := token.Header["typ"].(string)
+			if typ != cfg.Typ {
+				return nil, jwt.ErrTokenUnverifiable
+			}
+		}
+		return ed25519.PublicKey(cfg.PublicKey), nil
+	}, opts...)
+	if err != nil {
+		return authctx.Identity{}, false
+	}
+	if claims.Subject == "" || claims.SessionID == "" {
+		return authctx.Identity{}, false
+	}
+
+	return authctx.Identity{
+		SubjectID:   claims.Subject,
+		SubjectKind: claims.SubjectKind,
+		SessionID:   claims.SessionID,
+		JTI:         claims.ID,
+	}, true
+}
+
+// BearerToken достаёт токен из заголовка Authorization.
+func BearerToken(header string) (string, bool) {
+	const prefix = "Bearer "
+	if !strings.HasPrefix(header, prefix) {
+		return "", false
+	}
+	token := strings.TrimSpace(strings.TrimPrefix(header, prefix))
+	return token, token != ""
+}
+
+// Auth проверяет токен и кладёт личность в контекст.
+//
+// Отказ отдаётся через onUnauthorized: формат ошибки у сервисов разный —
+// у api это http.Error, у ir конверт {"error":{"code","message"}}, — и
+// навязывать его отсюда нечем.
+//
+// Дополнительные проверки поверх личности (живая сессия, роли, тенант)
+// навешиваются своим middleware следом: они ходят в базу, а этот пакет
+// про базу не знает.
+func Auth(cfg AuthConfig, onUnauthorized func(http.ResponseWriter, *http.Request)) Middleware {
+	deny := onUnauthorized
+	if deny == nil {
+		deny = func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		}
+	}
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			raw, ok := BearerToken(r.Header.Get("Authorization"))
+			if !ok {
+				deny(w, r)
+				return
+			}
+
+			identity, ok := ParseAndVerifyAccessToken(raw, cfg)
+			if !ok {
+				deny(w, r)
+				return
+			}
+
+			next.ServeHTTP(w, r.WithContext(authctx.WithIdentity(r.Context(), identity)))
+		})
+	}
+}

--- a/packages/core/transport/middleware.go
+++ b/packages/core/transport/middleware.go
@@ -1,0 +1,170 @@
+package transport
+
+import (
+	"log/slog"
+	"net/http"
+	"time"
+)
+
+// Middleware — обёртка обработчика. Отдельный тип, чтобы Chain читался.
+type Middleware func(http.Handler) http.Handler
+
+// Chain навешивает обёртки в порядке перечисления: первая оказывается внешней.
+func Chain(h http.Handler, middlewares ...Middleware) http.Handler {
+	for i := len(middlewares) - 1; i >= 0; i-- {
+		h = middlewares[i](h)
+	}
+	return h
+}
+
+// Recorder запоминает статус ответа и факт первой записи.
+//
+// Нужен двоим: логу — чтобы писать статус, а Recover — чтобы понимать, можно
+// ли ещё отдать тело ошибки. Поэтому Logger должен стоять снаружи Recover:
+// обёртку создаёт он.
+type Recorder struct {
+	http.ResponseWriter
+	status  int
+	written bool
+}
+
+func (rec *Recorder) Status() int   { return rec.status }
+func (rec *Recorder) Written() bool { return rec.written }
+
+func (rec *Recorder) WriteHeader(status int) {
+	if rec.written {
+		return
+	}
+	rec.status = status
+	rec.written = true
+	rec.ResponseWriter.WriteHeader(status)
+}
+
+func (rec *Recorder) Write(b []byte) (int, error) {
+	if !rec.written {
+		rec.WriteHeader(http.StatusOK)
+	}
+	return rec.ResponseWriter.Write(b)
+}
+
+// Logger пишет метод, путь, статус и длительность.
+func Logger(log *slog.Logger) Middleware {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			started := time.Now()
+			rec := &Recorder{ResponseWriter: w, status: http.StatusOK}
+			next.ServeHTTP(rec, r)
+			log.Info("request",
+				"method", r.Method,
+				"path", r.URL.Path,
+				"status", rec.status,
+				"duration_ms", time.Since(started).Milliseconds())
+		})
+	}
+}
+
+// Recover ловит панику и отдаёт ответ через onPanic — формат ошибки у каждого
+// сервиса свой, и навязывать его отсюда нечем.
+//
+// Если тело уже отправлено, корректный ответ дописать нельзя: второй
+// WriteHeader даёт «superfluous WriteHeader» в логе вместо самой паники.
+// В этом случае соединение рвётся — клиент увидит обрыв, а не притворно
+// успешный ответ.
+func Recover(log *slog.Logger, onPanic func(http.ResponseWriter, *http.Request)) Middleware {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			rec, _ := w.(*Recorder)
+			defer func() {
+				if p := recover(); p != nil {
+					log.Error("panic", "recover", p, "path", r.URL.Path)
+					if rec != nil && rec.Written() {
+						panic(http.ErrAbortHandler)
+					}
+					if onPanic != nil {
+						onPanic(w, r)
+						return
+					}
+					http.Error(w, "internal server error", http.StatusInternalServerError)
+				}
+			}()
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// CORSConfig — то, что различается между сервисами. Пустой AllowedMethods
+// означает набор по умолчанию.
+type CORSConfig struct {
+	// Whitelist в формате config.ParseCORSWhitelist: "*" — обычный ключ.
+	Whitelist      map[string]bool
+	AllowedMethods string
+	// MaxAge в секундах. Ноль — заголовок не ставится, и префлайт полетит
+	// перед каждым запросом.
+	MaxAge int
+}
+
+const defaultAllowedMethods = "GET, POST, PUT, PATCH, DELETE, OPTIONS"
+
+// CORS выставляет заголовки одинаково во всех сервисах платформы.
+//
+// Authorization и credentials идут только явно разрешённому источнику: вместе
+// с «*» браузер их всё равно отвергнет. Vary: Origin ставится и в отказе —
+// ответ зависит от Origin в обоих случаях, и без него кэш отдал бы чужому
+// источнику ответ, собранный для разрешённого.
+func CORS(cfg CORSConfig) Middleware {
+	methods := cfg.AllowedMethods
+	if methods == "" {
+		methods = defaultAllowedMethods
+	}
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			wildcard := cfg.Whitelist["*"]
+
+			var allowedOrigin string
+			if wildcard {
+				allowedOrigin = "*"
+			} else if origin := r.Header.Get("Origin"); cfg.Whitelist[origin] {
+				allowedOrigin = origin
+			}
+
+			if !wildcard {
+				w.Header().Add("Vary", "Origin")
+			}
+
+			if allowedOrigin != "" {
+				allowHeaders := "Content-Type"
+				if allowedOrigin != "*" {
+					allowHeaders += ", Authorization"
+					w.Header().Set("Access-Control-Allow-Credentials", "true")
+				}
+				w.Header().Set("Access-Control-Allow-Origin", allowedOrigin)
+				w.Header().Set("Access-Control-Allow-Methods", methods)
+				w.Header().Set("Access-Control-Allow-Headers", allowHeaders)
+				if cfg.MaxAge > 0 {
+					w.Header().Set("Access-Control-Max-Age", itoa(cfg.MaxAge))
+				}
+			}
+
+			if r.Method == http.MethodOptions {
+				w.WriteHeader(http.StatusNoContent)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(buf[i:])
+}


### PR DESCRIPTION
По ревью [sb0rka/ir#1](https://github.com/sb0rka/ir/pull/1): «имеет смысл вынести в core, используем везде в api, auth, ir».

## Зачем

Логгер, recover, CORS и проверка access-токена написаны в каждом сервисе заново. Одинаковыми они при этом не получились:

- `apps/api` ставит `Vary: Origin` только в разрешающей ветке — кэш может отдать чужому источнику ответ, собранный для разрешённого
- статус ответа в лог не пишет никто, отличить 501 от 500 по логам нельзя
- паника посреди уже отправленного тела даёт второй `WriteHeader` и «superfluous WriteHeader» в логе вместо самой паники
- `Access-Control-Max-Age` не выставлен, префлайт летит перед каждым запросом

Расхождения такого рода растут молча, а починка одного из них не чинит остальные.

## Что в пакете

| | |
|---|---|
| `Chain`, `Middleware` | порядок обёрток |
| `Recorder` | статус ответа и факт первой записи |
| `Logger` | метод, путь, статус, длительность |
| `Recover` | паника; после первой записи рвёт соединение |
| `CORS` | формат whitelist из `config.ParseCORSWhitelist` |
| `Auth` | разбор и проверка Ed25519-токена платформы |
| `ParseAndVerifyAccessToken`, `BearerToken` | по отдельности, если своё middleware |

## Решения, которые стоит оспорить

**Формат ошибки не навязывается.** `Recover` и `Auth` принимают функцию отрисовки: у `apps/api` это `http.Error`, у `ir` конверт `{"error":{"code","message"}}`. Общим может быть момент отказа, но не его вид.

**Проверки поверх личности сюда не переехали** — живая сессия, роли, тенант ходят в базу, а пакет про базу не знает. Навешиваются следом своим middleware, как сейчас в `apps/api`.

**Логгер обязан стоять снаружи `Recover`**: `Recorder` создаёт он, а `Recover` по этой обёртке понимает, было ли уже что-то записано.

## Что дальше

Этот PR только добавляет пакет — ни один сервис на него ещё не переключён, поведение не меняется. После мержа и тега:

1. `apps/api` — заменить свои `corsMiddleware`/`authMiddleware`
2. `ir` — то же самое, там уже используются `coreconfig`, `corelog`, `corestore` и `coreauthctx`

Проверено: `go build`, `go vet` на `packages/core`.